### PR TITLE
Parse graph to extract protein seq

### DIFF
--- a/grodecoder.py
+++ b/grodecoder.py
@@ -543,9 +543,9 @@ def main(input_file_path, draw_graph_option=False, check_overlapping_residue=Fal
 
     if draw_graph_option:
         logger.info("Drawing graphs...")
-        filename = Path(filepath_gro).stem
+        filename = Path(input_file_path).stem
         for index_graph, graph_count in enumerate(graph_count_dict.keys()):
-            print_graph(graph_count, f"./{filename}_{index_graph}.png")
+            print_graph(graph_count, f"{filename}_{index_graph}.png")
 
     protein_sequence = {}
     for index_graph, graph in enumerate(graph_count_dict.keys()):

--- a/grodecoder.py
+++ b/grodecoder.py
@@ -479,6 +479,8 @@ def extract_protein_sequence(graph):
     The correspondence between 3-letter code and 1-letter code
     is taken from MDAnalysis:
     https://docs.mdanalysis.org/1.0.1/_modules/MDAnalysis/lib/util.html#convert_aa_code
+    See also the list of known residue names in MDAnalysis:
+    https://userguide.mdanalysis.org/stable/standard_selections.html#proteins
 
     Parameters
     ----------

--- a/grodecoder.py
+++ b/grodecoder.py
@@ -492,7 +492,7 @@ def extract_protein_sequence(graph):
         str
             Protein sequence.
     """
-    logger.info("Extractig protein sequence...")
+    logger.info("Extractigg protein sequence...")
     AMINO_ACID_DICT = mda.lib.util.inverse_aa_codes
     protein_sequence = []
     # graph.nodes.items() returns an iterable of tuples (node_id, node_attributes).


### PR DESCRIPTION
This PR uses:
- `graph.nodes.items()` to parse all node attributes at once.
- the dictionnary provided by MDAanalysis for the 3-letter code -> 1-letter code residue conversion.